### PR TITLE
Use ai-playbook fix branch for prompt output delimiter

### DIFF
--- a/.github/workflows/ai-orchestrator.yml
+++ b/.github/workflows/ai-orchestrator.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-orchestrator.yml@v0.1.19
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-orchestrator.yml@fix/prompt-output-delimiter
     with:
       # Align to your OpenCode GitHub install selection:
       # Provider: Z.AI Coding Plan, Model: GLM-4.7
@@ -31,3 +31,4 @@ jobs:
       # Either name works; reusable workflow normalizes it.
       ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
       ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+


### PR DESCRIPTION
Temporarily points reusable workflow ref to fix/prompt-output-delimiter for verification. After merge+tag, replace this with a pinned tag.