### PR TITLE
fix(workflows): add triage dispatcher and pin playbook SHA

### DIFF
--- a/.github/workflows/ai-daily.yml
+++ b/.github/workflows/ai-daily.yml
@@ -15,7 +15,4 @@ concurrency:
 
 jobs:
   call:
-    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-daily.yml@18822dbf6a08d9f579d344a8cac974e047842ffc
-    timeout-minutes: 15
-
-
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-daily.yml@fd2898a18cb21cf32aca87b5c2084fa2218968c0

--- a/.github/workflows/ai-triage-dispatcher.yml
+++ b/.github/workflows/ai-triage-dispatcher.yml
@@ -1,0 +1,33 @@
+name: AI Triage Dispatcher (on CI failure)
+
+on:
+  workflow_run:
+    workflows: [""ci""]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: ai-triage-dispatcher-$\{\{ github.repository \}\}
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    if: $\{\{ github.event.workflow_run.conclusion == 'failure' \}\}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch AI Triage (workflow_dispatch)
+        shell: bash
+        env:
+          GH_TOKEN: $\{\{ github.token \}\}
+          REPO: $\{\{ github.repository \}\}
+          RUN_ID: $\{\{ github.event.workflow_run.id \}\}
+          RUN_URL: $\{\{ github.event.workflow_run.html_url \}\}
+        run: |
+          set -euo pipefail
+          echo ""Dispatching AI Triage for failing run: $RUN_ID""
+          gh workflow run -R ""$REPO"" ai-triage.yml \
+            -f failing_run_id=""$RUN_ID"" \
+            -f failing_run_url=""$RUN_URL""

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -1,10 +1,16 @@
 name: AI Triage
 
 on:
-  workflow_run:
-    workflows: ["CI"]     # JP: あなたのCI workflow名に合わせる / EN: match your CI name
-    types: [completed]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      failing_run_id:
+        description: "Failing CI run ID (from dispatcher)"
+        required: true
+        type: string
+      failing_run_url:
+        description: "Failing CI run URL (optional)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -19,8 +25,7 @@ concurrency:
 
 jobs:
   call:
-    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-triage.yml@18822dbf6a08d9f579d344a8cac974e047842ffc
-    timeout-minutes: 30
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-triage.yml@fd2898a18cb21cf32aca87b5c2084fa2218968c0
     with:
       # Align to your OpenCode GitHub install selection:
       # Provider: Z.AI Coding Plan, Model: GLM-4.7

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -16,7 +16,4 @@ concurrency:
 
 jobs:
   call:
-    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-watchdog.yml@18822dbf6a08d9f579d344a8cac974e047842ffc
-    timeout-minutes: 10
-
-
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-watchdog.yml@fd2898a18cb21cf32aca87b5c2084fa2218968c0


### PR DESCRIPTION
EN:
- Add ai-triage-dispatcher.yml: workflow_run(CI failure) -> workflow_dispatch(ai-triage).
- Update ai-triage.yml to workflow_dispatch inputs and pass failing_run_id/url to reusable.
- Pin ai-watchdog/ai-daily/ai-triage to the new ai-playbook commit SHA (fd2898a18cb21cf32aca87b5c2084fa2218968c0).
- Remove timeout-minutes from wrappers if present (caller uses-job must not set it).

JP:
- ai-triage-dispatcher.yml を追加（CI failure を検知して ai-triage を dispatch）。
- ai-triage.yml を workflow_dispatch 入力化し、failing_run_id/url をreusableへ渡す。
- ai-watchdog/ai-daily/ai-triage の playbook 参照を新SHAへpin。
- wrapper 側の timeout-minutes（存在すれば）を除去。
Rollback: git revert this commit.