### PR TITLE
fix(workflows): add triage dispatcher and pin playbook SHA

### DIFF
--- a/.github/workflows/ai-daily.yml
+++ b/.github/workflows/ai-daily.yml
@@ -15,4 +15,4 @@ concurrency:
 
 jobs:
   call:
-    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-daily.yml@fd2898a18cb21cf32aca87b5c2084fa2218968c0
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-daily.yml@ce0d8fc7f92a7bc65e3bdab0a709516cf0ded1ed

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   call:
-    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-triage.yml@fd2898a18cb21cf32aca87b5c2084fa2218968c0
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-triage.yml@ce0d8fc7f92a7bc65e3bdab0a709516cf0ded1ed
     with:
       # Align to your OpenCode GitHub install selection:
       # Provider: Z.AI Coding Plan, Model: GLM-4.7

--- a/.github/workflows/ai-watchdog.yml
+++ b/.github/workflows/ai-watchdog.yml
@@ -16,4 +16,4 @@ concurrency:
 
 jobs:
   call:
-    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-watchdog.yml@fd2898a18cb21cf32aca87b5c2084fa2218968c0
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-watchdog.yml@ce0d8fc7f92a7bc65e3bdab0a709516cf0ded1ed


### PR DESCRIPTION
EN:
- Add ai-triage-dispatcher.yml: workflow_run(CI failure) -> workflow_dispatch(ai-triage).
- Update ai-triage.yml to workflow_dispatch inputs and pass failing_run_id/url to reusable.
- Pin ai-watchdog/ai-daily/ai-triage to the new ai-playbook commit SHA (ce0d8fc7f92a7bc65e3bdab0a709516cf0ded1ed).
- Remove timeout-minutes from wrappers if present (caller uses-job must not set it).

JP:
- ai-triage-dispatcher.yml を追加（CI failure を検知して ai-triage を dispatch）。
- ai-triage.yml を workflow_dispatch 入力化し、failing_run_id/url をreusableへ渡す。
- ai-watchdog/ai-daily/ai-triage の playbook 参照を新SHAへpin。
- wrapper 側の timeout-minutes（存在すれば）を除去。
Rollback: git revert this commit.