### PR TITLE
ci(workflows): add ai:ready dispatcher wrapper

### DIFF
--- a/.github/workflows/ai-issue-dispatcher.yml
+++ b/.github/workflows/ai-issue-dispatcher.yml
@@ -1,0 +1,28 @@
+name: AI Issue Dispatcher (ai:ready)
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+concurrency:
+  group: ai-issue-dispatcher-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: ${{ github.event.label.name == 'ai:ready' }}
+    uses: mizunotaro/ai-playbook/.github/workflows/reuse-ai-orchestrator.yml@main
+    with:
+      # SSOT: primary model
+      model: "zai/glm-4.7"
+      # Pin OpenCode version for stability (can be updated by SSOT later)
+      opencode_version: "1.1.44"
+      job_timeout_minutes: 45
+      opencode_step_timeout_minutes: 20
+    secrets: inherit


### PR DESCRIPTION
Issue 2: Add dispatcher wrapper (ai:ready -> reusable orchestrator)

- Trigger: issues:labeled (ai:ready)
- Guard: reusable workflow checks vars.AI_AUTOMATION_MODE == RUN (else exit)
- Secrets: inherit (requires ZAI_API_KEY or ZHIPU_API_KEY in caller repo)
