### PR TITLE
Fix required checks: ai-prereqs-check should run for all PRs

### DIFF
--- a/.github/workflows/ai-prereqs-check.yml
+++ b/.github/workflows/ai-prereqs-check.yml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - '.github/workflows/**'
-      - 'ops/scripts/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Remove pull_request paths filter to avoid missing required checks on PRs.